### PR TITLE
Use a separate class to hold each ZMQ socket

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -10,6 +10,46 @@ Net::Async::ZMQ - IO::Async support for ZeroMQ
 
 version 0.001
 
+=head1 SYNOPSIS
+
+  use IO::Async::Loop;
+  use Net::Async::ZMQ;
+  use Net::Async::ZMQ::Socket;
+
+  use ZMQ::LibZMQ3;  # or ZMQ::LibZMQ4
+  use ZMQ::Constants qw(ZMQ_REQ ZMQ_NOBLOCK);
+
+  my $loop = IO::Async::Loop->new;
+
+  my $ctx = zmq_init();
+  my $client_socket = zmq_socket( $ctx, ZMQ_REQ );
+  zmq_connect( $client_socket, "tcp://127.0.0.1:9999" );
+
+  my $counter = 0;
+
+  my $zmq = Net::Async::ZMQ->new;
+
+  $zmq->add_child(
+    Net::Async::ZMQ::Socket->new(
+      socket => $client_socket,
+      on_read_ready => sub {
+        while ( my $recvmsg = zmq_recvmsg( $client_socket, ZMQ_NOBLOCK ) ) {
+          my $msg = zmq_msg_data($recvmsg);
+          zmq_sendmsg( $client_socket, "hello @{[ $counter++ ]}" );
+        }
+      },
+    )
+  );
+
+  $loop->add( $zmq );
+
+  $loop->run;
+
+=head1 DESCRIPTION
+
+A subclass of L<IO::Async::Notifier> that can hold ZMQ sockets
+that are provided by L<Net::Async::ZMQ::Socket>.
+
 =head1 AUTHOR
 
 Zakariyya Mughal <zmughal@cpan.org>

--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,6 @@ version = 0.001
 
 [@Author::ZMUGHAL]
 AutoPrereqs.skip[0] = ^Alien::ZMQ::latest$
+
+[OSPrereqs / MSWin32]
+Win32API::File = 0.08

--- a/lib/Net/Async/ZMQ/Socket.pm
+++ b/lib/Net/Async/ZMQ/Socket.pm
@@ -1,0 +1,104 @@
+package Net::Async::ZMQ::Socket;
+# ABSTRACT: Use a ZMQ socket asynchronously using IO::Async
+
+use strict;
+use warnings;
+
+use Package::Stash;
+
+use ZMQ::Constants qw(ZMQ_FD);
+use Fcntl qw(O_RDONLY);
+use if $^O eq 'MSWin32', 'Win32API::File' => qw(OsFHandleOpenFd);
+
+use base qw( IO::Async::Handle );
+
+=method configure
+
+  method configure( %params )
+
+=cut
+sub configure {
+	my ($self, %params) = @_;
+
+	for (qw(socket)) {
+		$self->{$_} = delete $params{$_} if exists $params{$_};
+	}
+
+
+	if( exists $self->{socket} ) {
+		my $zmq_libzmq_class;
+		my $socket = $self->{socket};
+		if( $socket->isa('ZMQ::LibZMQ3::Socket') ) {
+			$zmq_libzmq_class = 'ZMQ::LibZMQ3';
+		} elsif( $socket->isa('ZMQ::LibZMQ4::Socket') ) {
+			$zmq_libzmq_class = 'ZMQ::LibZMQ4';
+		} else {
+			die "Unknown ZMQ socket: $socket";
+		}
+
+		$self->{_stash} = Package::Stash->new($zmq_libzmq_class);
+
+		$params{read_handle} = $self->_zmq_get_io_handle($self->{socket});
+
+	}
+
+	$self->SUPER::configure(%params);
+}
+
+=method socket
+
+  method socket()
+
+Returns the underlying ZMQ socket. See the C<socket> parameter.
+
+=cut
+sub socket {
+	my ($self) = @_;
+	$self->{socket};
+}
+
+sub _zmq_get_io_handle {
+	my ($self, $socket) = @_;
+
+	my $zmq_getsockopt = $self->{_stash}->get_symbol('&zmq_getsockopt');
+	my $zmq_getsockopt_uint64 = $self->{_stash}->get_symbol('&zmq_getsockopt_uint64');
+
+	my $fd;
+
+	if( $^O eq 'MSWin32' ) {
+		# `SOCKET` data type is a `uint64` on Windows x64.
+		my $socket_handle = $zmq_getsockopt_uint64->( $socket, ZMQ_FD );
+		# Converts OS socket handle to a C runtime file descriptor.
+		$fd = OsFHandleOpenFd($socket_handle, O_RDONLY);
+	} else {
+		$fd = $zmq_getsockopt->( $socket, ZMQ_FD );
+	}
+
+	# Use dup() on the ZMQ file descriptor so that Perl can close the
+	# handle without closing the ZMQ handle.
+	#
+	# Also, avoid using IO::Handle here due to how it closes the file
+	# handle automatically.
+	open(my $io_handle, "<&", $fd);
+
+	$io_handle;
+}
+
+1;
+__END__
+=head1 DESCRIPTION
+
+A subclass of L<IO::Async::Handle> that works with ZMQ sockets.
+
+It currently handles sockets from both L<ZMQ::LibZMQ3> and L<ZMQ::LibZMQ4> on
+both Unix-like systems and Windows.
+
+=head1 PARAMETERS
+
+=head2 socket
+
+A ZMQ socket.
+
+Takes the type
+
+  InstanceOf['ZMQ::LibZMQ3::Socket'] | InstanceOf['ZMQ::LibZMQ4::Socket']


### PR DESCRIPTION
This creates `Net::Async::ZMQ::Socket` as a subclass of
`IO::Async::Handle`.
